### PR TITLE
Added variable remote name, fix for PVE 7+, cloud retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When setting up the encryption, I DO NOT reccomend you encrypt the filenames and
 ```
 apt-get install git
 cd /root
-git clone https://github.com/TheRealAlexV/proxmox-vzbackup-rclone.git
+git clone https://github.com/Marko298/proxmox-vzbackup-rclone.git
 chmod +x /root/proxmox-vzbackup-rclone/vzbackup-rclone.sh
 ```
 

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -15,7 +15,11 @@ rehydrate=${2} #enter the date you want to rehydrate in the following format: YY
 if [ ! -z "${3}" ];then
         CMDARCHIVE=$(echo "/${3}" | sed -e 's/\(.bin\)*$//g')
 fi
-tarfile=${TARFILE}
+if [ -z ${TARGET+x} ]; then 
+    tarfile=${TARFILE}
+else
+    tarfile=${TARGET}
+fi
 exten=${tarfile#*.}
 filename=${tarfile%.*.*}
 

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -84,5 +84,5 @@ if [[ ${COMMAND} == 'job-end' ||  ${COMMAND} == 'job-abort' ]]; then
     -v --stats=60s --transfers=16 --checkers=16
 
     rclone --config /root/.config/rclone/rclone.conf \
-      delete --min-age $MAX_CLOUD_AGEd -v $drive:backups/
+      delete --min-age $MAX_CLOUD_AGEd $drive:backups/
 fi

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -4,7 +4,7 @@
 ############ /START CONFIG
 drive="gd-backup_crypt"
 dumpdir="/mnt/pve/pvebackups01/dump" # Set this to where your vzdump files are stored
-clouddir="backups" # Set this to desired cloud folder
+backups="backups" # Set this to desired cloud folder
 MAX_AGE=3 # This is the age in days to keep local backup copies. Local backups older than this are deleted.
 MAX_CLOUD_AGE=31 # This is the age in days to keep cloud backup copies. Cloud backups older than this are deleted
 ############ /END CONFIG

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -2,6 +2,7 @@
 # ./vzbackup-rclone.sh rehydrate YYYY/MM/DD file_name_encrypted.bin
 
 ############ /START CONFIG
+drive="gd-backup_crypt"
 dumpdir="/mnt/pve/pvebackups01/dump" # Set this to where your vzdump files are stored
 MAX_AGE=3 # This is the age in days to keep local backup copies. Local backups older than this are deleted.
 MAX_CLOUD_AGE=31 # This is the age in days to keep cloud backup copies. Cloud backups older than this are deleted
@@ -29,7 +30,7 @@ if [[ ${COMMAND} == 'rehydrate' ]]; then
     #echo "For example, today would be: $timepath"
     #read -p 'Rehydrate Date => ' rehydrate
     rclone --config /root/.config/rclone/rclone.conf \
-    --drive-chunk-size=32M copy gd-backup_crypt:/$rehydrate$CMDARCHIVE $dumpdir \
+    --drive-chunk-size=32M copy $drive:/$rehydrate$CMDARCHIVE $dumpdir \
     -v --stats=60s --transfers=16 --checkers=16
 fi
 
@@ -43,7 +44,7 @@ if [[ ${COMMAND} == 'backup-end' ]]; then
     echo "rcloning $rclonedir"
     
     rclone --config /root/.config/rclone/rclone.conf \
-    --drive-chunk-size=32M copy $tarfile gd-backup_crypt:/$timepath \
+    --drive-chunk-size=32M copy $tarfile $drive:/$timepath \
     -v --stats=60s --transfers=16 --checkers=16
 fi
 
@@ -79,9 +80,9 @@ if [[ ${COMMAND} == 'job-end' ||  ${COMMAND} == 'job-abort' ]]; then
     echo "rcloning $_filename4"
 
     rclone --config /root/.config/rclone/rclone.conf \
-    --drive-chunk-size=32M move $_filename4 gd-backup_crypt:/$timepath \
+    --drive-chunk-size=32M move $_filename4 $drive:/$timepath \
     -v --stats=60s --transfers=16 --checkers=16
-    
+
     rclone --config /root/.config/rclone/rclone.conf \
-      delete --min-age $MAX_CLOUD_AGEd -vv gd-backup_crypt:backups/
+      delete --min-age $MAX_CLOUD_AGEd -v $drive:backups/
 fi

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -84,5 +84,5 @@ if [[ ${COMMAND} == 'job-end' ||  ${COMMAND} == 'job-abort' ]]; then
     -v --stats=60s --transfers=16 --checkers=16
 
     rclone --config /root/.config/rclone/rclone.conf \
-      delete --min-age $MAX_CLOUD_AGEd $drive:backups/
+      delete --min-age ${MAX_CLOUD_AGE}d $drive:backups/
 fi

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -4,6 +4,7 @@
 ############ /START CONFIG
 dumpdir="/mnt/pve/pvebackups01/dump" # Set this to where your vzdump files are stored
 MAX_AGE=3 # This is the age in days to keep local backup copies. Local backups older than this are deleted.
+MAX_CLOUD_AGE=31 # This is the age in days to keep cloud backup copies. Cloud backups older than this are deleted
 ############ /END CONFIG
 
 _bdir="$dumpdir"
@@ -39,10 +40,8 @@ fi
 
 if [[ ${COMMAND} == 'backup-end' ]]; then
     echo "Backing up $tarfile to remote storage"
-    #mkdir -p $rclonedir
-    #cp -v $tarfile $rclonedir
     echo "rcloning $rclonedir"
-    #ls $rclonedir
+    
     rclone --config /root/.config/rclone/rclone.conf \
     --drive-chunk-size=32M copy $tarfile gd-backup_crypt:/$timepath \
     -v --stats=60s --transfers=16 --checkers=16
@@ -75,14 +74,14 @@ if [[ ${COMMAND} == 'job-end' ||  ${COMMAND} == 'job-abort' ]]; then
     tar -cvzPf "$_filename4" $_tdir/*.tar
 
     # copy config archive to backup folder
-    #mkdir -p $rclonedir
     cp -v $_filename4 $_bdir/
-    #cp -v $_filename4 $rclonedir/
+
     echo "rcloning $_filename4"
-    #ls $rclonedir
+
     rclone --config /root/.config/rclone/rclone.conf \
     --drive-chunk-size=32M move $_filename4 gd-backup_crypt:/$timepath \
     -v --stats=60s --transfers=16 --checkers=16
-
-    #rm -rfv $rcloneroot
+    
+    rclone --config /root/.config/rclone/rclone.conf \
+      delete --min-age $MAX_CLOUD_AGEd -vv gd-backup_crypt:backups/
 fi

--- a/vzbackup-rclone.sh
+++ b/vzbackup-rclone.sh
@@ -10,7 +10,7 @@ MAX_CLOUD_AGE=31 # This is the age in days to keep cloud backup copies. Cloud ba
 
 _bdir="$dumpdir"
 rcloneroot="$dumpdir/rclone"
-timepath="$(date +%Y)/$(date +%m)/$(date +%d)"
+timepath="$(date +%Y-%m-%d)"
 rclonedir="$rcloneroot/$timepath"
 COMMAND=${1}
 rehydrate=${2} #enter the date you want to rehydrate in the following format: YYYY/MM/DD


### PR DESCRIPTION
This pull adds features like:
- Retention for number of days in cloud
- Fix target variable for new PVE versions
- Configurable name of the rclone remote